### PR TITLE
gtk3: Migrate CSS to GTK3 (#3-01)

### DIFF
--- a/subprojects/gtk3-pm/assignments/gtk3-task-3-01/ASSIGNED.md
+++ b/subprojects/gtk3-pm/assignments/gtk3-task-3-01/ASSIGNED.md
@@ -1,0 +1,14 @@
+---
+assignment: gtk3-task-3-01
+title: Migrate CSS to GTK3
+assignee: senior-eng-03
+status: started
+start_date: 2026-02-07
+issue: "#3"
+---
+
+Acceptance Criteria:
+- Port CSS to GTK3, replacing deprecated selectors and styles.
+- Visual appearance matches GTK3 expectations.
+- No GTK/CSS warnings during build/run related to styles.
+- Visual smoke tests pass (if present) or manual verification recorded.


### PR DESCRIPTION
# Migrate CSS to GTK3

This assignment covers porting CSS to GTK3, replacing deprecated selectors and styles.

## Acceptance Criteria
- Port CSS to GTK3, replacing deprecated selectors and styles.
- Visual appearance matches GTK3 expectations.
- No GTK/CSS warnings during build/run related to styles.
- Visual smoke tests pass (if present) or manual verification recorded.

Refs: #3