### PR TITLE
gtk3: Adwaita compatibility layer (#2-01)

### DIFF
--- a/subprojects/gtk3-pm/assignments/gtk3-task-2-01/ASSIGNED.md
+++ b/subprojects/gtk3-pm/assignments/gtk3-task-2-01/ASSIGNED.md
@@ -1,0 +1,15 @@
+# Task 2 - Adwaita compatibility layer
+
+Assignee: senior-eng-02
+Start-Date: $(date -I)
+
+Description:
+- Implement an Adwaita compatibility layer for the gtk3 port to align styling with the Adwaita theme.
+- Provide helpers and CSS overrides to map Adwaita variables for GTK3.
+
+Acceptance Criteria:
+- A new ASSIGNED.md is added with this metadata.
+- A draft PR is opened titled "gtk3: Adwaita compatibility layer (#2-01)" and labeled gtk3-port, needs-review.
+- A compile check is run and results are reported in the PR.
+
+References: Issue #2


### PR DESCRIPTION
# Task 2 - Adwaita compatibility layer

Assignee: senior-eng-02
Start-Date: $(date -I)

Description:
- Implement an Adwaita compatibility layer for the gtk3 port to align styling with the Adwaita theme.
- Provide helpers and CSS overrides to map Adwaita variables for GTK3.

Acceptance Criteria:
- A new ASSIGNED.md is added with this metadata.
- A draft PR is opened titled "gtk3: Adwaita compatibility layer (#2-01)" and labeled gtk3-port, needs-review.
- A compile check is run and results are reported in the PR.

References: Issue #2


## Compile check

### Meson setup
The Meson build system
Version: 1.10.1
Source dir: /home/natalie/Projects/gnome-software-gtk3
Build dir: /home/natalie/Projects/gnome-software-gtk3/builddir
Build type: native build
Project name: gnome-software
Project version: 50.beta
C compiler for the host machine: /usr/bin/ccache cc (gcc 15.2.1 "cc (GCC) 15.2.1 20260103")
C linker for the host machine: cc ld.bfd 2.45.1
Host machine cpu family: x86_64
Host machine cpu: x86_64
Compiler for C supports arguments -fstack-protector-strong: YES (cached)
Compiler for C supports arguments -Waggregate-return: YES (cached)
Compiler for C supports arguments -Warray-bounds: YES (cached)
Compiler for C supports arguments -Wcast-align: YES (cached)
Compiler for C supports arguments -Wclobbered: YES (cached)
Compiler for C supports arguments -Wdeclaration-after-statement: YES (cached)
Compiler for C supports arguments -Wempty-body: YES (cached)
Compiler for C supports arguments -Wenum-compare: YES (cached)
Compiler for C supports arguments -Wenum-conversion: YES (cached)
Compiler for C supports arguments -Wenum-int-mismatch: YES (cached)
Compiler for C supports arguments -Wformat=2: YES (cached)
Compiler for C supports arguments -Wformat-nonliteral: YES (cached)
Compiler for C supports arguments -Wformat-security: YES (cached)
Compiler for C supports arguments -Wformat-signedness: YES (cached)
Compiler for C supports arguments -Wignored-qualifiers: YES (cached)
Compiler for C supports arguments -Wimplicit-function-declaration: YES (cached)
Compiler for C supports arguments -Werror=implicit-function-declaration: YES (cached)
Compiler for C supports arguments -Winit-self: YES (cached)
Compiler for C supports arguments -Wmaybe-uninitialized: YES (cached)
Compiler for C supports arguments -Wmissing-declarations: YES (cached)
Compiler for C supports arguments -Wmissing-format-attribute: YES (cached)
Compiler for C supports arguments -Wmissing-include-dirs: YES (cached)
Compiler for C supports arguments -Wmissing-noreturn: YES (cached)
Compiler for C supports arguments -Wmissing-parameter-type: YES (cached)
Compiler for C supports arguments -Wmissing-prototypes: YES (cached)
Compiler for C supports arguments -Wnested-externs: YES (cached)
Compiler for C supports arguments -Werror=nested-externs: YES (cached)
Compiler for C supports arguments -Wno-missing-field-initializers: YES (cached)
Compiler for C supports arguments -Wno-strict-aliasing: YES (cached)
Compiler for C supports arguments -Wno-suggest-attribute=format: YES (cached)
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wnull-dereference: YES (cached)
Compiler for C supports arguments -Wold-style-definition: YES (cached)
Compiler for C supports arguments -Woverride-init: YES (cached)
Compiler for C supports arguments -Wpacked: YES (cached)
Compiler for C supports arguments -Wpointer-arith: YES (cached)
Compiler for C supports arguments -Wredundant-decls: YES (cached)
Compiler for C supports arguments -Wreturn-type: YES (cached)
Compiler for C supports arguments -Wshadow: YES (cached)
Compiler for C supports arguments -Wsign-compare: YES (cached)
Compiler for C supports arguments -Wstrict-aliasing: YES (cached)
Compiler for C supports arguments -Wstrict-prototypes: YES (cached)
Compiler for C supports arguments -Wswitch-default: YES (cached)
Compiler for C supports arguments -Wtype-limits: YES (cached)
Compiler for C supports arguments -Wundef: YES (cached)
Compiler for C supports arguments -Wuninitialized: YES (cached)
Compiler for C supports arguments -Wunused-but-set-variable: YES (cached)
Compiler for C supports arguments -Wwrite-strings: YES (cached)
Compiler for C supports link arguments -Wl,-z,relro: YES (cached)
Compiler for C supports link arguments -Wl,-z,now: YES (cached)
Has header "linux/unistd.h" : YES (cached)
Dependency appstream found: YES 1.1.1 (cached)
Dependency gdk-pixbuf-2.0 found: YES 2.44.4 (cached)
Dependency xmlb found: YES 0.3.24 (cached)
Dependency gio-unix-2.0 found: YES 2.87.2 (cached)
Dependency gmodule-2.0 found: YES 2.87.2 (cached)
Dependency gtk4 found: YES 4.21.5 (cached)
Dependency glib-2.0 found: YES 2.87.2 (cached)
Dependency gsettings-desktop-schemas found: YES 50.alpha (cached)
Dependency json-glib-1.0 found: YES 1.10.8 (cached)
Library m found: YES
Dependency libsoup-3.0 found: YES 3.6.5 (cached)
Dependency libadwaita-1 found: YES 1.9.alpha (cached)
Header "glib.h" has symbol "G_FORMAT_SIZE_ONLY_VALUE" with dependency glib-2.0: YES (cached)
Dependency sysprof-capture-4 found: YES 50.alpha (cached)
Dependency polkit-gobject-1 found: YES 127 (cached)
Dependency packagekit-glib2 found: YES 1.3.3 (cached)
Dependency fwupd found: YES 2.0.19 (cached)
Dependency flatpak found: YES 1.16.3 (cached)
Dependency ostree-1 found: YES 2025.7 (cached)
Dependency malcontent-0 found: YES 0.14.alpha (cached)
Dependency gudev-1.0 found: YES 238 (cached)

Executing subproject gnome-pwa-list 

gnome-pwa-list| Project name: gnome-pwa-list
gnome-pwa-list| Project version: undefined
gnome-pwa-list| Program python3 found: YES (/usr/bin/python3)
gnome-pwa-list| Build targets in project: 0
gnome-pwa-list| Subproject gnome-pwa-list finished.

Dependency systemd found: YES 259 (cached)
Configuring config.h using configuration
Program msgfmt found: YES (/usr/bin/msgfmt)
Program appstreamcli found: YES (/usr/bin/appstreamcli)
Dependency gio-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/glib-compile-schemas found: YES (/usr/bin/glib-compile-schemas)
Found git repository at /home/natalie/Projects/gnome-software-gtk3
Dependency glib-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums)
Dependency glib-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums)
Found pkg-config: YES (/usr/bin/pkg-config) 2.5.1
Found pkg-config: YES (/usr/bin/pkg-config) 2.5.1
Dependency gio-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/glib-compile-resources found: YES (/usr/bin/glib-compile-resources)
Program tar found: YES (/usr/bin/tar)
Dependency gio-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/gdbus-codegen found: YES (/usr/bin/gdbus-codegen)
Program gdbus-codegen found: YES (/usr/bin/gdbus-codegen)
Found CMake: /usr/bin/cmake (4.2.3)
Run-time dependency glib-testing-0 found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency glib-testing-0

Executing subproject libglib-testing 

libglib-testing| Project name: libglib-testing
libglib-testing| Project version: 0.1.1
libglib-testing| C compiler for the host machine: /usr/bin/ccache cc (gcc 15.2.1 "cc (GCC) 15.2.1 20260103")
libglib-testing| C linker for the host machine: cc ld.bfd 2.45.1
libglib-testing| Configuring config.h using configuration
libglib-testing| Compiler for C supports arguments -fno-strict-aliasing: YES (cached)
libglib-testing| Compiler for C supports arguments -fstack-protector-strong: YES (cached)
libglib-testing| Compiler for C supports arguments -Waggregate-return: YES (cached)
libglib-testing| Compiler for C supports arguments -Wall: YES (cached)
libglib-testing| Compiler for C supports arguments -Wunused: YES (cached)
libglib-testing| Compiler for C supports arguments -Warray-bounds: YES (cached)
libglib-testing| Compiler for C supports arguments -Wcast-align: YES (cached)
libglib-testing| Compiler for C supports arguments -Wclobbered: YES (cached)
libglib-testing| Compiler for C supports arguments -Wno-declaration-after-statement: YES (cached)
libglib-testing| Compiler for C supports arguments -Wduplicated-branches: YES (cached)
libglib-testing| Compiler for C supports arguments -Wduplicated-cond: YES (cached)
libglib-testing| Compiler for C supports arguments -Wempty-body: YES (cached)
libglib-testing| Compiler for C supports arguments -Wformat=2: YES (cached)
libglib-testing| Compiler for C supports arguments -Wformat-nonliteral: YES (cached)
libglib-testing| Compiler for C supports arguments -Wformat-security: YES (cached)
libglib-testing| Compiler for C supports arguments -Wformat-signedness: YES (cached)
libglib-testing| Compiler for C supports arguments -Wignored-qualifiers: YES (cached)
libglib-testing| Compiler for C supports arguments -Wimplicit-function-declaration: YES (cached)
libglib-testing| Compiler for C supports arguments -Wincompatible-pointer-types: YES (cached)
libglib-testing| Compiler for C supports arguments -Wincompatible-pointer-types-discards-qualifiers: NO (cached)
libglib-testing| Compiler for C supports arguments -Winit-self: YES (cached)
libglib-testing| Compiler for C supports arguments -Wint-conversion: YES (cached)
libglib-testing| Compiler for C supports arguments -Wlogical-op: YES (cached)
libglib-testing| Compiler for C supports arguments -Wmisleading-indentation: YES (cached)
libglib-testing| Compiler for C supports arguments -Wmissing-declarations: YES (cached)
libglib-testing| Compiler for C supports arguments -Wmissing-format-attribute: YES (cached)
libglib-testing| Compiler for C supports arguments -Wmissing-include-dirs: YES (cached)
libglib-testing| Compiler for C supports arguments -Wmissing-noreturn: YES (cached)
libglib-testing| Compiler for C supports arguments -Wmissing-parameter-type: YES (cached)
libglib-testing| Compiler for C supports arguments -Wmissing-prototypes: YES (cached)
libglib-testing| Compiler for C supports arguments -Wnested-externs: YES (cached)
libglib-testing| Compiler for C supports arguments -Wno-error=cpp: YES (cached)
libglib-testing| Compiler for C supports arguments -Wno-discarded-qualifiers: YES (cached)
libglib-testing| Compiler for C supports arguments -Wno-missing-field-initializers: YES (cached)
libglib-testing| Compiler for C supports arguments -Wno-suggest-attribute=format: YES (cached)
libglib-testing| Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
libglib-testing| Compiler for C supports arguments -Wnull-dereference: YES (cached)
libglib-testing| Compiler for C supports arguments -Wold-style-definition: YES (cached)
libglib-testing| Compiler for C supports arguments -Woverflow: YES (cached)
libglib-testing| Compiler for C supports arguments -Woverride-init: YES (cached)
libglib-testing| Compiler for C supports arguments -Wparentheses: YES (cached)
libglib-testing| Compiler for C supports arguments -Wpointer-arith: YES (cached)
libglib-testing| Compiler for C supports arguments -Wredundant-decls: YES (cached)
libglib-testing| Compiler for C supports arguments -Wreturn-type: YES (cached)
libglib-testing| Compiler for C supports arguments -Wshadow: YES (cached)
libglib-testing| Compiler for C supports arguments -Wsign-compare: YES (cached)
libglib-testing| Compiler for C supports arguments -Wstrict-aliasing=2: YES (cached)
libglib-testing| Compiler for C supports arguments -Wstrict-prototypes: YES (cached)
libglib-testing| Compiler for C supports arguments -Wswitch-default: YES (cached)
libglib-testing| Compiler for C supports arguments -Wswitch-enum: YES (cached)
libglib-testing| Compiler for C supports arguments -Wtype-limits: YES (cached)
libglib-testing| Compiler for C supports arguments -Wundef: YES (cached)
libglib-testing| Compiler for C supports arguments -Wuninitialized: YES (cached)
libglib-testing| Compiler for C supports arguments -Wunused-but-set-variable: YES (cached)
libglib-testing| Compiler for C supports arguments -Wunused-result: YES (cached)
libglib-testing| Compiler for C supports arguments -Wunused-variable: YES (cached)
libglib-testing| Compiler for C supports arguments -Wwrite-strings: YES (cached)
libglib-testing| subprojects/libglib-testing/meson.build:91: WARNING: Consider using the built-in warning_level option instead of using "-Wall".
libglib-testing| Dependency gio-2.0 found: YES 2.87.2 (cached)
libglib-testing| Dependency glib-2.0 found: YES 2.87.2 (cached)
libglib-testing| Dependency gobject-2.0 found: YES 2.87.2 (cached)
libglib-testing| Configuring version.xml using configuration
libglib-testing| Program gtkdoc-scan found: YES (/usr/bin/gtkdoc-scan)
libglib-testing| Program gtkdoc-scangobj found: YES (/usr/bin/gtkdoc-scangobj)
libglib-testing| Program gtkdoc-mkdb found: YES (/usr/bin/gtkdoc-mkdb)
libglib-testing| Program gtkdoc-mkhtml found: YES (/usr/bin/gtkdoc-mkhtml)
libglib-testing| Program gtkdoc-fixxref found: YES (/usr/bin/gtkdoc-fixxref)
libglib-testing| Dependency gio-2.0 found: YES 2.87.2 (cached)
libglib-testing| Dependency glib-2.0 found: YES 2.87.2 (cached)
libglib-testing| Dependency gobject-2.0 found: YES 2.87.2 (cached)
libglib-testing| Build targets in project: 53
libglib-testing| Subproject libglib-testing finished.

Dependency glib-testing-0 from subproject subprojects/libglib-testing found: YES 0.1.1
Dependency gio-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/glib-compile-resources found: YES (/usr/bin/glib-compile-resources)
Dependency gio-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/gdbus-codegen found: YES (/usr/bin/gdbus-codegen)
Dependency glib-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums)
Dependency glib-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/glib-mkenums found: YES (/usr/bin/glib-mkenums)
Dependency gio-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/gdbus-codegen found: YES (/usr/bin/gdbus-codegen)
Dependency gio-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/gdbus-codegen found: YES (/usr/bin/gdbus-codegen)
Dependency gio-2.0 found: YES 2.87.2 (cached)
Program /usr/bin/gdbus-codegen found: YES (/usr/bin/gdbus-codegen)
Configuring org.gnome.Software.service using configuration
Configuring org.gnome.Software.desktop.tmp using configuration
Configuring gnome-software-local-file-flatpak.desktop.tmp using configuration
Configuring gnome-software-local-file-fwupd.desktop.tmp using configuration
Configuring gnome-software-local-file-packagekit.desktop.tmp using configuration
Configuring gnome-software.service using configuration
Program xsltproc found: YES (/usr/bin/xsltproc)
Configuring org.freedesktop.PackageKit.service using configuration
Program msginit found: YES (/usr/bin/msginit)
Program msgmerge found: YES (/usr/bin/msgmerge)
Program xgettext found: YES (/usr/bin/xgettext)
Program gtkdoc-scan found: YES (/usr/bin/gtkdoc-scan)
Program gtkdoc-scangobj found: YES (/usr/bin/gtkdoc-scangobj)
Program gtkdoc-mkdb found: YES (/usr/bin/gtkdoc-mkdb)
Program gtkdoc-mkhtml found: YES (/usr/bin/gtkdoc-mkhtml)
Program gtkdoc-fixxref found: YES (/usr/bin/gtkdoc-fixxref)
Program itstool found: YES (/usr/bin/itstool)
Program msgmerge found: YES (/usr/bin/msgmerge)
Program msgfmt found: YES (/usr/bin/msgfmt)
Build targets in project: 199

gnome-software 50.beta

  Misc
    Flatpak http backend: curl

  Subprojects
    gnome-pwa-list      : YES
    libglib-testing     : YES 1 warnings

Found ninja-1.13.2 at /usr/bin/ninja
Generating targets:   0%|          | 0/199 eta ?Generating targets:  12%|█▏        | 24/199 eta 00:00Generating targets:  34%|███▎      | 67/199 eta 00:00                                                     Writing build.ninja:   0%|          | 0/477 eta ?                                                 ninja: warning: premature end of file; recovering
Cleaning... 0 files.


### Ninja dry-run
ninja: Entering directory `builddir'
ninja: warning: premature end of file; recovering
[1/367] Generating lib/gs-build-ident.h with a custom command
[2/367] Generating GObject enum file lib/gs-enums.c (wrapped by meson because command contains newlines, to capture output)
[3/367] Generating GObject enum file lib/gs-enums.h (wrapped by meson because command contains newlines, to capture output)
[4/367] Generating GObject enum file src/gs-enums.c (wrapped by meson because command contains newlines, to capture output)
[5/367] Generating GObject enum file src/gs-enums.h (wrapped by meson because command contains newlines, to capture output)
[6/367] Compiling C object lib/tools/profile-key-colors.p/profile-key-colors.c.o
[7/367] Compiling C object lib/tools/profile-key-colors.p/.._gs-key-colors.c.o
[8/367] Generating symbol file subprojects/libglib-testing/libglib-testing/libglib-testing-0.so.0.1.1.p/libglib-testing-0.so.0.1.1.symbols
[9/367] Compiling C object subprojects/libglib-testing/libglib-testing/tests/dbus-queue.p/dbus-queue.c.o
[10/367] Compiling C object subprojects/libglib-testing/libglib-testing/tests/signal-logger.p/signal-logger.c.o
[11/367] Compiling C object src/gnome-software-restarter.p/gs-restarter.c.o
[12/367] Generating yelp doc help/bg/help-gnome-software-bg-gmo
[13/367] Generating yelp doc help/ca/help-gnome-software-ca-gmo
[14/367] Generating yelp doc help/cs/help-gnome-software-cs-gmo
[15/367] Generating yelp doc help/de/help-gnome-software-de-gmo
[16/367] Generating yelp doc help/el/help-gnome-software-el-gmo
[17/367] Generating yelp doc help/eu/help-gnome-software-eu-gmo
[18/367] Generating yelp doc help/fr/help-gnome-software-fr-gmo
[19/367] Generating yelp doc help/hu/help-gnome-software-hu-gmo
[20/367] Generating yelp doc help/id/help-gnome-software-id-gmo
[21/367] Generating yelp doc help/it/help-gnome-software-it-gmo
[22/367] Generating yelp doc help/nl/help-gnome-software-nl-gmo
[23/367] Generating yelp doc help/pt_BR/help-gnome-software-pt_BR-gmo
[24/367] Generating yelp doc help/ru/help-gnome-software-ru-gmo
[25/367] Generating yelp doc help/sv/help-gnome-software-sv-gmo
[26/367] Generating yelp doc help/uk/help-gnome-software-uk-gmo
[27/367] Merging translations for data/metainfo/org.gnome.Software.metainfo.xml
[28/367] Merging translations for plugins/flatpak/org.gnome.Software.Plugin.Flatpak.metainfo.xml
[29/367] Generating plugins/flatpak/tests/flatpak-self-test-data with a custom command
[30/367] Merging translations for plugins/fwupd/org.gnome.Software.Plugin.Fwupd.metainfo.xml
[31/367] Merging translations for plugins/epiphany/org.gnome.Software.Plugin.Epiphany.metainfo.xml
[32/367] Merging translations for src/org.gnome.Software.desktop
[33/367] Merging translations for src/gnome-software-local-file-flatpak.desktop
[34/367] Merging translations for src/gnome-software-local-file-fwupd.desktop
[35/367] Merging translations for src/gnome-software-local-file-packagekit.desktop
[36/367] Generating src/manfile-gnome-software with a custom command
[37/367] Building translation po/ab/LC_MESSAGES/gnome-software-ab.mo
[38/367] Building translation po/af/LC_MESSAGES/gnome-software-af.mo
[39/367] Building translation po/ar/LC_MESSAGES/gnome-software-ar.mo
[40/367] Building translation po/as/LC_MESSAGES/gnome-software-as.mo
[41/367] Building translation po/be/LC_MESSAGES/gnome-software-be.mo
[42/367] Building translation po/bg/LC_MESSAGES/gnome-software-bg.mo
[43/367] Building translation po/bn/LC_MESSAGES/gnome-software-bn.mo
[44/367] Building translation po/bs/LC_MESSAGES/gnome-software-bs.mo
[45/367] Building translation po/ca/LC_MESSAGES/gnome-software-ca.mo
[46/367] Building translation po/ca@valencia/LC_MESSAGES/gnome-software-ca@valencia.mo
[47/367] Building translation po/ckb/LC_MESSAGES/gnome-software-ckb.mo
[48/367] Building translation po/cs/LC_MESSAGES/gnome-software-cs.mo
[49/367] Building translation po/da/LC_MESSAGES/gnome-software-da.mo
[50/367] Building translation po/de/LC_MESSAGES/gnome-software-de.mo
[51/367] Building translation po/el/LC_MESSAGES/gnome-software-el.mo
[52/367] Building translation po/en_GB/LC_MESSAGES/gnome-software-en_GB.mo
[53/367] Building translation po/eo/LC_MESSAGES/gnome-software-eo.mo
[54/367] Building translation po/es/LC_MESSAGES/gnome-software-es.mo
[55/367] Building translation po/eu/LC_MESSAGES/gnome-software-eu.mo
[56/367] Building translation po/fa/LC_MESSAGES/gnome-software-fa.mo
[57/367] Building translation po/fi/LC_MESSAGES/gnome-software-fi.mo
[58/367] Building translation po/fil/LC_MESSAGES/gnome-software-fil.mo
[59/367] Building translation po/fr/LC_MESSAGES/gnome-software-fr.mo
[60/367] Building translation po/fur/LC_MESSAGES/gnome-software-fur.mo
[61/367] Building translation po/ga/LC_MESSAGES/gnome-software-ga.mo
[62/367] Building translation po/gd/LC_MESSAGES/gnome-software-gd.mo
[63/367] Building translation po/gl/LC_MESSAGES/gnome-software-gl.mo
[64/367] Building translation po/he/LC_MESSAGES/gnome-software-he.mo
[65/367] Building translation po/hi/LC_MESSAGES/gnome-software-hi.mo
[66/367] Building translation po/hr/LC_MESSAGES/gnome-software-hr.mo
[67/367] Building translation po/hu/LC_MESSAGES/gnome-software-hu.mo
[68/367] Building translation po/ia/LC_MESSAGES/gnome-software-ia.mo
[69/367] Building translation po/id/LC_MESSAGES/gnome-software-id.mo
[70/367] Building translation po/ie/LC_MESSAGES/gnome-software-ie.mo
[71/367] Building translation po/is/LC_MESSAGES/gnome-software-is.mo
[72/367] Building translation po/it/LC_MESSAGES/gnome-software-it.mo
[73/367] Building translation po/ja/LC_MESSAGES/gnome-software-ja.mo
[74/367] Building translation po/ka/LC_MESSAGES/gnome-software-ka.mo
[75/367] Building translation po/kab/LC_MESSAGES/gnome-software-kab.mo
[76/367] Building translation po/kk/LC_MESSAGES/gnome-software-kk.mo
[77/367] Building translation po/km/LC_MESSAGES/gnome-software-km.mo
[78/367] Building translation po/ko/LC_MESSAGES/gnome-software-ko.mo
[79/367] Building translation po/lt/LC_MESSAGES/gnome-software-lt.mo
[80/367] Building translation po/lv/LC_MESSAGES/gnome-software-lv.mo
[81/367] Building translation po/mjw/LC_MESSAGES/gnome-software-mjw.mo
[82/367] Building translation po/ml/LC_MESSAGES/gnome-software-ml.mo
[83/367] Building translation po/mr/LC_MESSAGES/gnome-software-mr.mo
[84/367] Building translation po/ms/LC_MESSAGES/gnome-software-ms.mo
[85/367] Building translation po/nb/LC_MESSAGES/gnome-software-nb.mo
[86/367] Building translation po/ne/LC_MESSAGES/gnome-software-ne.mo
[87/367] Building translation po/nl/LC_MESSAGES/gnome-software-nl.mo
[88/367] Building translation po/oc/LC_MESSAGES/gnome-software-oc.mo
[89/367] Building translation po/pa/LC_MESSAGES/gnome-software-pa.mo
[90/367] Building translation po/pl/LC_MESSAGES/gnome-software-pl.mo
[91/367] Building translation po/pt/LC_MESSAGES/gnome-software-pt.mo
[92/367] Building translation po/pt_BR/LC_MESSAGES/gnome-software-pt_BR.mo
[93/367] Building translation po/ro/LC_MESSAGES/gnome-software-ro.mo
[94/367] Building translation po/ru/LC_MESSAGES/gnome-software-ru.mo
[95/367] Building translation po/sk/LC_MESSAGES/gnome-software-sk.mo
[96/367] Building translation po/sl/LC_MESSAGES/gnome-software-sl.mo
[97/367] Building translation po/sr/LC_MESSAGES/gnome-software-sr.mo
[98/367] Building translation po/sr@latin/LC_MESSAGES/gnome-software-sr@latin.mo
[99/367] Building translation po/sv/LC_MESSAGES/gnome-software-sv.mo
[100/367] Building translation po/te/LC_MESSAGES/gnome-software-te.mo
[101/367] Building translation po/th/LC_MESSAGES/gnome-software-th.mo
[102/367] Building translation po/tr/LC_MESSAGES/gnome-software-tr.mo
[103/367] Building translation po/ug/LC_MESSAGES/gnome-software-ug.mo
[104/367] Building translation po/uk/LC_MESSAGES/gnome-software-uk.mo
[105/367] Building translation po/uz/LC_MESSAGES/gnome-software-uz.mo
[106/367] Building translation po/vi/LC_MESSAGES/gnome-software-vi.mo
[107/367] Building translation po/zh_CN/LC_MESSAGES/gnome-software-zh_CN.mo
[108/367] Building translation po/zh_HK/LC_MESSAGES/gnome-software-zh_HK.mo
[109/367] Building translation po/zh_TW/LC_MESSAGES/gnome-software-zh_TW.mo
[110/367] Compiling C object lib/libgnomesoftware.so.23.p/meson-generated_.._gs-enums.c.o
[111/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-app.c.o
[112/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-app-list.c.o
[113/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-app-permissions.c.o
[114/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-app-query.c.o
[115/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-appstream.c.o
[116/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-category.c.o
[117/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-category-manager.c.o
[118/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-debug.c.o
[119/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-desktop-data.c.o
[120/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-download-utils.c.o
[121/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-external-appstream-utils.c.o
[122/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-fedora-third-party.c.o
[123/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-icon.c.o
[124/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-icon-downloader.c.o
[125/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-ioprio.c.o
[126/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-job-manager.c.o
[127/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-key-colors.c.o
[128/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-metered.c.o
[129/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-odrs-provider.c.o
[130/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-os-release.c.o
[131/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin.c.o
[132/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-event.c.o
[133/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-helpers.c.o
[134/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job.c.o
[135/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-cancel-offline-update.c.o
[136/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-download-upgrade.c.o
[137/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-file-to-app.c.o
[138/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-get-offline-update-state.c.o
[139/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-launch.c.o
[140/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-list-apps.c.o
[141/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-list-categories.c.o
[142/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-list-distro-upgrades.c.o
[143/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-manage-repository.c.o
[144/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-refine.c.o
[145/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-refresh-metadata.c.o
[146/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-set-offline-update-action.c.o
[147/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-trigger-upgrade.c.o
[148/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-install-apps.c.o
[149/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-uninstall-apps.c.o
[150/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-update-apps.c.o
[151/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-job-url-to-app.c.o
[152/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-loader.c.o
[153/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-plugin-loader-sync.c.o
[154/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-remote-icon.c.o
[155/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-rewrite-resources.c.o
[156/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-test.c.o
[157/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-utils.c.o
[158/367] Compiling C object lib/libgnomesoftware.so.23.p/gs-worker-thread.c.o
[159/367] Compiling C object lib/gnome-software-cmd.p/meson-generated_.._gs-enums.c.o
[160/367] Compiling C object lib/gnome-software-cmd.p/gs-cmd.c.o
[161/367] Compiling C object lib/gs-self-test.p/meson-generated_.._gs-enums.c.o
[162/367] Compiling C object lib/gs-self-test.p/gs-self-test.c.o
[163/367] Compiling C object lib/tests/app-permissions.p/meson-generated_.._.._gs-enums.c.o
[164/367] Compiling C object lib/tests/app-permissions.p/app-permissions.c.o
[165/367] Compiling C object plugins/core/libgs_plugin_generic-updates.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[166/367] Compiling C object plugins/core/libgs_plugin_generic-updates.so.p/gs-plugin-generic-updates.c.o
[167/367] Compiling C object plugins/core/libgs_plugin_provenance.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[168/367] Compiling C object plugins/core/libgs_plugin_provenance.so.p/gs-plugin-provenance.c.o
[169/367] Compiling C object plugins/core/libgs_plugin_provenance-license.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[170/367] Compiling C object plugins/core/libgs_plugin_provenance-license.so.p/gs-plugin-provenance-license.c.o
[171/367] Compiling C object plugins/core/libgs_plugin_icons.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[172/367] Compiling C object plugins/core/libgs_plugin_icons.so.p/gs-plugin-icons.c.o
[173/367] Compiling C object plugins/core/libgs_plugin_appstream.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[174/367] Compiling C object plugins/core/libgs_plugin_appstream.so.p/gs-plugin-appstream.c.o
[175/367] Compiling C object plugins/core/libgs_plugin_hardcoded-blocklist.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[176/367] Compiling C object plugins/core/libgs_plugin_hardcoded-blocklist.so.p/gs-plugin-hardcoded-blocklist.c.o
[177/367] Compiling C object plugins/core/libgs_plugin_os-release.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[178/367] Compiling C object plugins/core/libgs_plugin_os-release.so.p/gs-plugin-os-release.c.o
[179/367] Compiling C object plugins/core/gs-self-test-core.p/meson-generated_.._.._.._lib_gs-enums.c.o
[180/367] Compiling C object plugins/core/gs-self-test-core.p/gs-self-test.c.o
[181/367] Compiling C object plugins/dpkg/libgs_plugin_dpkg.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[182/367] Compiling C object plugins/dpkg/libgs_plugin_dpkg.so.p/gs-plugin-dpkg.c.o
[183/367] Compiling C object plugins/dpkg/gs-self-test-dpkg.p/meson-generated_.._.._.._lib_gs-enums.c.o
[184/367] Compiling C object plugins/dpkg/gs-self-test-dpkg.p/gs-self-test.c.o
[185/367] Compiling C object plugins/dummy/libgs_plugin_dummy.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[186/367] Compiling C object plugins/dummy/libgs_plugin_dummy.so.p/gs-plugin-dummy.c.o
[187/367] Compiling C object plugins/dummy/gs-self-test-dummy.p/meson-generated_.._gs-resources.c.o
[188/367] Compiling C object plugins/dummy/gs-self-test-dummy.p/meson-generated_.._.._.._lib_gs-enums.c.o
[189/367] Compiling C object plugins/dummy/gs-self-test-dummy.p/gs-self-test.c.o
[190/367] Compiling C object plugins/fedora-langpacks/libgs_plugin_fedora-langpacks.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[191/367] Compiling C object plugins/fedora-langpacks/libgs_plugin_fedora-langpacks.so.p/gs-plugin-fedora-langpacks.c.o
[192/367] Compiling C object plugins/fedora-langpacks/gs-self-test-fedora-langpacks.p/meson-generated_.._.._.._lib_gs-enums.c.o
[193/367] Compiling C object plugins/fedora-langpacks/gs-self-test-fedora-langpacks.p/gs-self-test.c.o
[194/367] Compiling C object plugins/fedora-pkgdb-collections/libgs_plugin_fedora-pkgdb-collections.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[195/367] Compiling C object plugins/fedora-pkgdb-collections/libgs_plugin_fedora-pkgdb-collections.so.p/gs-plugin-fedora-pkgdb-collections.c.o
[196/367] Compiling C object plugins/flatpak/libgs_plugin_flatpak.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[197/367] Compiling C object plugins/flatpak/libgs_plugin_flatpak.so.p/gs-flatpak-app.c.o
[198/367] Compiling C object plugins/flatpak/libgs_plugin_flatpak.so.p/gs-flatpak.c.o
[199/367] Compiling C object plugins/flatpak/libgs_plugin_flatpak.so.p/gs-flatpak-transaction.c.o
[200/367] Compiling C object plugins/flatpak/libgs_plugin_flatpak.so.p/gs-flatpak-utils.c.o
[201/367] Compiling C object plugins/flatpak/libgs_plugin_flatpak.so.p/gs-plugin-flatpak.c.o
[202/367] Compiling C object plugins/flatpak/gs-self-test-flatpak.p/meson-generated_.._.._.._lib_gs-enums.c.o
[203/367] Compiling C object plugins/flatpak/gs-self-test-flatpak.p/gs-flatpak-app.c.o
[204/367] Compiling C object plugins/flatpak/gs-self-test-flatpak.p/gs-self-test.c.o
[205/367] Compiling C object plugins/fwupd/libgs_plugin_fwupd.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[206/367] Compiling C object plugins/fwupd/libgs_plugin_fwupd.so.p/gs-fwupd-app.c.o
[207/367] Compiling C object plugins/fwupd/libgs_plugin_fwupd.so.p/gs-plugin-fwupd.c.o
[208/367] Compiling C object plugins/fwupd/gs-self-test-fwupd.p/meson-generated_.._.._.._lib_gs-enums.c.o
[209/367] Compiling C object plugins/fwupd/gs-self-test-fwupd.p/gs-self-test.c.o
[210/367] Compiling C object plugins/modalias/libgs_plugin_modalias.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[211/367] Compiling C object plugins/modalias/libgs_plugin_modalias.so.p/gs-plugin-modalias.c.o
[212/367] Compiling C object plugins/modalias/gs-self-test-modalias.p/meson-generated_.._.._.._lib_gs-enums.c.o
[213/367] Compiling C object plugins/modalias/gs-self-test-modalias.p/gs-self-test.c.o
[214/367] Compiling C object plugins/malcontent/libgs_plugin_malcontent.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[215/367] Compiling C object plugins/malcontent/libgs_plugin_malcontent.so.p/gs-plugin-malcontent.c.o
[216/367] Compiling C object plugins/packagekit/libgs_plugin_packagekit.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[217/367] Compiling C object plugins/packagekit/libgs_plugin_packagekit.so.p/gs-plugin-packagekit.c.o
[218/367] Compiling C object plugins/packagekit/libgs_plugin_packagekit.so.p/gs-packagekit-helper.c.o
[219/367] Compiling C object plugins/packagekit/libgs_plugin_packagekit.so.p/gs-packagekit-task.c.o
[220/367] Compiling C object plugins/packagekit/libgs_plugin_packagekit.so.p/packagekit-common.c.o
[221/367] Compiling C object plugins/packagekit/libgs_plugin_packagekit.so.p/gs-markdown.c.o
[222/367] Compiling C object plugins/packagekit/gs-self-test-packagekit.p/meson-generated_.._.._.._lib_gs-enums.c.o
[223/367] Compiling C object plugins/packagekit/gs-self-test-packagekit.p/gs-markdown.c.o
[224/367] Compiling C object plugins/packagekit/gs-self-test-packagekit.p/gs-self-test.c.o
[225/367] Compiling C object plugins/repos/libgs_plugin_repos.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[226/367] Compiling C object plugins/repos/libgs_plugin_repos.so.p/gs-plugin-repos.c.o
[227/367] Compiling C object plugins/repos/gs-self-test-repos.p/meson-generated_.._.._.._lib_gs-enums.c.o
[228/367] Compiling C object plugins/repos/gs-self-test-repos.p/gs-self-test.c.o
[229/367] Compiling C object plugins/epiphany/libgs_plugin_epiphany.so.p/meson-generated_.._gs-epiphany-generated.c.o
[230/367] Compiling C object plugins/epiphany/libgs_plugin_epiphany.so.p/meson-generated_.._.._.._lib_gs-enums.c.o
[231/367] Compiling C object plugins/epiphany/libgs_plugin_epiphany.so.p/gs-plugin-epiphany.c.o
[232/367] Compiling C object plugins/epiphany/gs-self-test-epiphany.p/meson-generated_.._gs-dynamic-launcher-portal-iface.c.o
[233/367] Compiling C object plugins/epiphany/gs-self-test-epiphany.p/meson-generated_.._gs-epiphany-generated.c.o
[234/367] Compiling C object plugins/epiphany/gs-self-test-epiphany.p/meson-generated_.._.._.._lib_gs-enums.c.o
[235/367] Compiling C object plugins/epiphany/gs-self-test-epiphany.p/gs-self-test.c.o
[236/367] Compiling C object src/gs-self-test-src.p/meson-generated_.._.._lib_gs-enums.c.o
[237/367] Compiling C object src/gs-self-test-src.p/gs-css.c.o
[238/367] Compiling C object src/gs-self-test-src.p/gs-common.c.o
[239/367] Compiling C object src/gs-self-test-src.p/gs-self-test.c.o
[240/367] Compiling C object src/gnome-software.p/meson-generated_.._gs-resources.c.o
[241/367] Compiling C object src/gnome-software.p/meson-generated_.._gs-shell-search-provider-generated.c.o
[242/367] Compiling C object src/gnome-software.p/meson-generated_.._gs-packagekit-generated.c.o
[243/367] Compiling C object src/gnome-software.p/meson-generated_.._gs-packagekit-modify2-generated.c.o
[244/367] Compiling C object src/gnome-software.p/meson-generated_.._gs-software-offline-updates-generated.c.o
[245/367] Compiling C object src/gnome-software.p/meson-generated_.._gs-enums.c.o
[246/367] Compiling C object src/gnome-software.p/meson-generated_.._.._lib_gs-enums.c.o
[247/367] Compiling C object src/gnome-software.p/gs-age-rating-context-dialog.c.o
[248/367] Compiling C object src/gnome-software.p/gs-app-addon-row.c.o
[249/367] Compiling C object src/gnome-software.p/gs-app-reviews-dialog.c.o
[250/367] Compiling C object src/gnome-software.p/gs-app-update-details-dialog.c.o
[251/367] Compiling C object src/gnome-software.p/gs-app-version-history-dialog.c.o
[252/367] Compiling C object src/gnome-software.p/gs-app-version-history-row.c.o
[253/367] Compiling C object src/gnome-software.p/gs-application.c.o
[254/367] Compiling C object src/gnome-software.p/gs-app-context-bar.c.o
[255/367] Compiling C object src/gnome-software.p/gs-app-details-page.c.o
[256/367] Compiling C object src/gnome-software.p/gs-app-row.c.o
[257/367] Compiling C object src/gnome-software.p/gs-app-tile.c.o
[258/367] Compiling C object src/gnome-software.p/gs-app-translation-dialog.c.o
[259/367] Compiling C object src/gnome-software.p/gs-basic-auth-dialog.c.o
[260/367] Compiling C object src/gnome-software.p/gs-category-page.c.o
[261/367] Compiling C object src/gnome-software.p/gs-category-tile.c.o
[262/367] Compiling C object src/gnome-software.p/gs-common.c.o
[263/367] Compiling C object src/gnome-software.p/gs-context-dialog-row.c.o
[264/367] Compiling C object src/gnome-software.p/gs-css.c.o
[265/367] Compiling C object src/gnome-software.p/gs-description-box.c.o
[266/367] Compiling C object src/gnome-software.p/gs-details-page.c.o
[267/367] Compiling C object src/gnome-software.p/gs-extras-page.c.o
[268/367] Compiling C object src/gnome-software.p/gs-feature-tile.c.o
[269/367] Compiling C object src/gnome-software.p/gs-featured-carousel.c.o
[270/367] Compiling C object src/gnome-software.p/gs-hardware-support-context-dialog.c.o
[271/367] Compiling C object src/gnome-software.p/gs-info-window.c.o
[272/367] Compiling C object src/gnome-software.p/gs-installed-page.c.o
[273/367] Compiling C object src/gnome-software.p/gs-installed-updates-dialog.c.o
[274/367] Compiling C object src/gnome-software.p/gs-language.c.o
[275/367] Compiling C object src/gnome-software.p/gs-layout-manager.c.o
[276/367] Compiling C object src/gnome-software.p/gs-license-tile.c.o
[277/367] Compiling C object src/gnome-software.p/gs-loading-page.c.o
[278/367] Compiling C object src/gnome-software.p/gs-lozenge.c.o
[279/367] Compiling C object src/gnome-software.p/gs-main.c.o
[280/367] Compiling C object src/gnome-software.p/gs-overview-page.c.o
[281/367] Compiling C object src/gnome-software.p/gs-origin-popover-row.c.o
[282/367] Compiling C object src/gnome-software.p/gs-os-update-page.c.o
[283/367] Compiling C object src/gnome-software.p/gs-page.c.o
[284/367] Compiling C object src/gnome-software.p/gs-prefs-dialog.c.o
[285/367] Compiling C object src/gnome-software.p/gs-progress-button.c.o
[286/367] Compiling C object src/gnome-software.p/gs-removal-dialog.c.o
[287/367] Compiling C object src/gnome-software.p/gs-repos-dialog.c.o
[288/367] Compiling C object src/gnome-software.p/gs-repos-section.c.o
[289/367] Compiling C object src/gnome-software.p/gs-repo-row.c.o
[290/367] Compiling C object src/gnome-software.p/gs-review-bar.c.o
[291/367] Compiling C object src/gnome-software.p/gs-review-dialog.c.o
[292/367] Compiling C object src/gnome-software.p/gs-review-histogram.c.o
[293/367] Compiling C object src/gnome-software.p/gs-review-row.c.o
[294/367] Compiling C object src/gnome-software.p/gs-safety-context-dialog.c.o
[295/367] Compiling C object src/gnome-software.p/gs-screenshot-carousel.c.o
[296/367] Compiling C object src/gnome-software.p/gs-screenshot-image.c.o
[297/367] Compiling C object src/gnome-software.p/gs-search-page.c.o
[298/367] Compiling C object src/gnome-software.p/gs-shell.c.o
[299/367] Compiling C object src/gnome-software.p/gs-shell-search-provider.c.o
[300/367] Compiling C object src/gnome-software.p/gs-software-offline-updates-provider.c.o
[301/367] Compiling C object src/gnome-software.p/gs-star-image.c.o
[302/367] Compiling C object src/gnome-software.p/gs-star-widget.c.o
[303/367] Compiling C object src/gnome-software.p/gs-storage-context-dialog.c.o
[304/367] Compiling C object src/gnome-software.p/gs-summary-tile.c.o
[305/367] Compiling C object src/gnome-software.p/gs-toast.c.o
[306/367] Compiling C object src/gnome-software.p/gs-update-list.c.o
[307/367] Compiling C object src/gnome-software.p/gs-update-monitor.c.o
[308/367] Compiling C object src/gnome-software.p/gs-updates-page.c.o
[309/367] Compiling C object src/gnome-software.p/gs-updates-paused-banner.c.o
[310/367] Compiling C object src/gnome-software.p/gs-updates-section.c.o
[311/367] Compiling C object src/gnome-software.p/gs-upgrade-banner.c.o
[312/367] Compiling C object src/gnome-software.p/gs-vendor.c.o
[313/367] Compiling C object src/gnome-software.p/gs-dbus-helper.c.o
[314/367] Linking target lib/tools/profile-key-colors
[315/367] Linking target subprojects/libglib-testing/libglib-testing/tests/dbus-queue
[316/367] Linking target subprojects/libglib-testing/libglib-testing/tests/signal-logger
[317/367] Linking target src/gnome-software-restarter
[318/367] Generating yelp doc help/bg/help-gnome-software-bg
[319/367] Generating yelp doc help/ca/help-gnome-software-ca
[320/367] Generating yelp doc help/cs/help-gnome-software-cs
[321/367] Generating yelp doc help/de/help-gnome-software-de
[322/367] Generating yelp doc help/el/help-gnome-software-el
[323/367] Generating yelp doc help/eu/help-gnome-software-eu
[324/367] Generating yelp doc help/fr/help-gnome-software-fr
[325/367] Generating yelp doc help/hu/help-gnome-software-hu
[326/367] Generating yelp doc help/id/help-gnome-software-id
[327/367] Generating yelp doc help/it/help-gnome-software-it
[328/367] Generating yelp doc help/nl/help-gnome-software-nl
[329/367] Generating yelp doc help/pt_BR/help-gnome-software-pt_BR
[330/367] Generating yelp doc help/ru/help-gnome-software-ru
[331/367] Generating yelp doc help/sv/help-gnome-software-sv
[332/367] Generating yelp doc help/uk/help-gnome-software-uk
[333/367] Linking target lib/libgnomesoftware.so.23
[334/367] Generating symbol file lib/libgnomesoftware.so.23.p/libgnomesoftware.so.23.symbols
[335/367] Linking target lib/gnome-software-cmd
[336/367] Linking target lib/gs-self-test
[337/367] Linking target lib/tests/app-permissions
[338/367] Linking target plugins/core/libgs_plugin_generic-updates.so
[339/367] Linking target plugins/core/libgs_plugin_provenance.so
[340/367] Linking target plugins/core/libgs_plugin_provenance-license.so
[341/367] Linking target plugins/core/libgs_plugin_icons.so
[342/367] Linking target plugins/core/libgs_plugin_appstream.so
[343/367] Linking target plugins/core/libgs_plugin_hardcoded-blocklist.so
[344/367] Linking target plugins/core/libgs_plugin_os-release.so
[345/367] Linking target plugins/core/gs-self-test-core
[346/367] Linking target plugins/dpkg/libgs_plugin_dpkg.so
[347/367] Linking target plugins/dpkg/gs-self-test-dpkg
[348/367] Linking target plugins/dummy/libgs_plugin_dummy.so
[349/367] Linking target plugins/dummy/gs-self-test-dummy
[350/367] Linking target plugins/fedora-langpacks/libgs_plugin_fedora-langpacks.so
[351/367] Linking target plugins/fedora-langpacks/gs-self-test-fedora-langpacks
[352/367] Linking target plugins/fedora-pkgdb-collections/libgs_plugin_fedora-pkgdb-collections.so
[353/367] Linking target plugins/flatpak/libgs_plugin_flatpak.so
[354/367] Linking target plugins/flatpak/gs-self-test-flatpak
[355/367] Linking target plugins/fwupd/libgs_plugin_fwupd.so
[356/367] Linking target plugins/fwupd/gs-self-test-fwupd
[357/367] Linking target plugins/modalias/libgs_plugin_modalias.so
[358/367] Linking target plugins/modalias/gs-self-test-modalias
[359/367] Linking target plugins/malcontent/libgs_plugin_malcontent.so
[360/367] Linking target plugins/packagekit/libgs_plugin_packagekit.so
[361/367] Linking target plugins/packagekit/gs-self-test-packagekit
[362/367] Linking target plugins/repos/libgs_plugin_repos.so
[363/367] Linking target plugins/repos/gs-self-test-repos
[364/367] Linking target plugins/epiphany/libgs_plugin_epiphany.so
[365/367] Linking target plugins/epiphany/gs-self-test-epiphany
[366/367] Linking target src/gnome-software
[367/367] Linking target src/gs-self-test-src
