### PR TITLE
website: add project site

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,20 @@
+name: Deploy site to GitHub Pages
+on:
+  push:
+    branches:
+      - main
+      - master
+      - '**'
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'docs'
+      - uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -9,12 +9,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pages: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs'
-      - uses: actions/deploy-pages@v1
+      - uses: actions/deploy-pages@v2

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>gnome-software-gtk3 - Project Site</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+body { font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial; max-width: 860px; margin: 2rem auto; line-height: 1.6; color: #333; padding: 0 1rem; background: #f6f8fa;}
+header h1 { margin: 0 0 0.5rem 0; }
+.card { border: 1px solid #e1e4e8; padding: 1rem; border-radius: 6px; background: #fff; }
+ul { margin-top: 0; }
+footer { color: #666; font-size: 0.9rem; margin-top: 1.5rem; }
+</style>
+</head>
+<body>
+<header>
+  <h1>gnome-software-gtk3</h1>
+  <p>Project website for the GTK3 port and UI updates.</p>
+</header>
+<main>
+  <section class="card">
+    <h2>Project Plan & Dashboard</h2>
+    <p>View the plan and dashboard in the repository:</p>
+    <ul>
+      <li><a href="subprojects/gtk3-pm/PROJECT-PLAN.md">PROJECT-PLAN.md</a></li>
+      <li><a href="subprojects/gtk3-pm/DASHBOARD.md">DASHBOARD.md</a></li>
+    </ul>
+  </section>
+  <section class="card" style="margin-top:1rem;">
+    <h2>Status</h2>
+    <p>Deploys are automated via GitHub Actions and published to GitHub Pages after merge.</p>
+  </section>
+  <footer>
+    <p>Repository: <a href="https://github.com/spivanatalie64/gnome-software-gtk3">https://github.com/spivanatalie64/gnome-software-gtk3</a></p>
+  </footer>
+</main>
+</body>
+</html>

--- a/subprojects/gtk3-pm/DASHBOARD.md
+++ b/subprojects/gtk3-pm/DASHBOARD.md
@@ -1,0 +1,5 @@
+# GTK3 Port Dashboard
+
+- Last updated: TBD
+- Assignments: None yet
+

--- a/subprojects/gtk3-pm/PROJECT-PLAN.md
+++ b/subprojects/gtk3-pm/PROJECT-PLAN.md
@@ -1,0 +1,5 @@
+# GTK3 Port Project Plan
+
+This repository contains the project plan for porting gnome-software to GTK3.
+
+(Short plan placeholder created by Copilot CLI.)

--- a/subprojects/gtk3-pm/assignments/gtk3-task-2-01/ASSIGNED.md
+++ b/subprojects/gtk3-pm/assignments/gtk3-task-2-01/ASSIGNED.md
@@ -1,0 +1,15 @@
+# Task 2 - Adwaita compatibility layer
+
+Assignee: senior-eng-02
+Start-Date: $(date -I)
+
+Description:
+- Implement an Adwaita compatibility layer for the gtk3 port to align styling with the Adwaita theme.
+- Provide helpers and CSS overrides to map Adwaita variables for GTK3.
+
+Acceptance Criteria:
+- A new ASSIGNED.md is added with this metadata.
+- A draft PR is opened titled "gtk3: Adwaita compatibility layer (#2-01)" and labeled gtk3-port, needs-review.
+- A compile check is run and results are reported in the PR.
+
+References: Issue #2


### PR DESCRIPTION
Adds a minimal project website under docs/ and a GitHub Actions workflow (.github/workflows/deploy-pages.yml) to deploy it to GitHub Pages after merge. Site includes links to PROJECT-PLAN.md and DASHBOARD.md in subprojects/gtk3-pm/. Acceptance criteria: site available at https://spivanatalie64.github.io/gnome-software-gtk3/ after merge and provisioning.